### PR TITLE
google: add utilities supporting upcoming oauth2 functionality

### DIFF
--- a/google/internal/externalaccount/clientauth.go
+++ b/google/internal/externalaccount/clientauth.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"encoding/base64"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/url"
+)
+
+// ClientAuthentication represents an OAuth client ID and secret and the mechanism for passing these credentials as stated in rfc6749#2.3.1.
+type ClientAuthentication struct {
+	// AuthStyle can be either basic or request-body
+	AuthStyle    oauth2.AuthStyle
+	ClientID     string
+	ClientSecret string
+}
+
+func (c *ClientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
+	if c.ClientID == "" || c.ClientSecret == "" || values == nil || headers == nil {
+		return
+	}
+
+	switch c.AuthStyle {
+	case oauth2.AuthStyleInHeader: // AuthStyleInHeader corresponds to basic authentication as defined in rfc7617#2
+		plainHeader := c.ClientID + ":" + c.ClientSecret
+		headers.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(plainHeader)))
+	case oauth2.AuthStyleInParams: // AuthStyleInParams corresponds to request-body authentication with ClientID and ClientSecret in the message body.
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	case oauth2.AuthStyleAutoDetect:
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	default:
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	}
+}

--- a/google/internal/externalaccount/clientauth_test.go
+++ b/google/internal/externalaccount/clientauth_test.go
@@ -1,0 +1,113 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+var clientID = "rbrgnognrhongo3bi4gb9ghg9g"
+var clientSecret = "notsosecret"
+
+var audience = []string{"32555940559.apps.googleusercontent.com"}
+var grantType = []string{"urn:ietf:params:oauth:grant-type:token-exchange"}
+var requestedTokenType = []string{"urn:ietf:params:oauth:token-type:access_token"}
+var subjectTokenType = []string{"urn:ietf:params:oauth:token-type:jwt"}
+var subjectToken = []string{"eyJhbGciOiJSUzI1NiIsImtpZCI6IjJjNmZhNmY1OTUwYTdjZTQ2NWZjZjI0N2FhMGIwOTQ4MjhhYzk1MmMiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiIzMjU1NTk0MDU1OS5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsImF1ZCI6IjMyNTU1OTQwNTU5LmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwic3ViIjoiMTEzMzE4NTQxMDA5MDU3Mzc4MzI4IiwiaGQiOiJnb29nbGUuY29tIiwiZW1haWwiOiJpdGh1cmllbEBnb29nbGUuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiI5OVJVYVFrRHJsVDFZOUV0SzdiYXJnIiwiaWF0IjoxNjAxNTgxMzQ5LCJleHAiOjE2MDE1ODQ5NDl9.SZ-4DyDcogDh_CDUKHqPCiT8AKLg4zLMpPhGQzmcmHQ6cJiV0WRVMf5Lq911qsvuekgxfQpIdKNXlD6yk3FqvC2rjBbuEztMF-OD_2B8CEIYFlMLGuTQimJlUQksLKM-3B2ITRDCxnyEdaZik0OVssiy1CBTsllS5MgTFqic7w8w0Cd6diqNkfPFZRWyRYsrRDRlHHbH5_TUnv2wnLVHBHlNvU4wU2yyjDIoqOvTRp8jtXdq7K31CDhXd47-hXsVFQn2ZgzuUEAkH2Q6NIXACcVyZOrjBcZiOQI9IRWz-g03LzbzPSecO7I8dDrhqUSqMrdNUz_f8Kr8JFhuVMfVug"}
+var scope = []string{"https://www.googleapis.com/auth/devstorage.full_control"}
+
+var ContentType = []string{"application/x-www-form-urlencoded"}
+
+func TestClientAuthentication_InjectHeaderAuthentication(t *testing.T) {
+	valuesH := url.Values{
+		"audience":             audience,
+		"grant_type":           grantType,
+		"requested_token_type": requestedTokenType,
+		"subject_token_type":   subjectTokenType,
+		"subject_token":        subjectToken,
+		"scope":                scope,
+	}
+	headerH := http.Header{
+		"Content-Type": ContentType,
+	}
+
+	headerAuthentication := ClientAuthentication{
+		AuthStyle:    oauth2.AuthStyleInHeader,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
+	headerAuthentication.InjectAuthentication(valuesH, headerH)
+
+	if got, want := valuesH["audience"], audience; !reflect.DeepEqual(got, want) {
+		t.Errorf("audience = %q, want %q", got, want)
+	}
+	if got, want := valuesH["grant_type"], grantType; !reflect.DeepEqual(got, want) {
+		t.Errorf("grant_type = %q, want %q", got, want)
+	}
+	if got, want := valuesH["requested_token_type"], requestedTokenType; !reflect.DeepEqual(got, want) {
+		t.Errorf("requested_token_type = %q, want %q", got, want)
+	}
+	if got, want := valuesH["subject_token_type"], subjectTokenType; !reflect.DeepEqual(got, want) {
+		t.Errorf("subject_token_type = %q, want %q", got, want)
+	}
+	if got, want := valuesH["subject_token"], subjectToken; !reflect.DeepEqual(got, want) {
+		t.Errorf("subject_token = %q, want %q", got, want)
+	}
+	if got, want := valuesH["scope"], scope; !reflect.DeepEqual(got, want) {
+		t.Errorf("scope = %q, want %q", got, want)
+	}
+	if got, want := headerH["Authorization"], []string{"Basic cmJyZ25vZ25yaG9uZ28zYmk0Z2I5Z2hnOWc6bm90c29zZWNyZXQ="}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Authorization in header = %q, want %q", got, want)
+	}
+}
+
+func TestClientAuthentication_ParamsAuthentication(t *testing.T) {
+	valuesP := url.Values{
+		"audience":             audience,
+		"grant_type":           grantType,
+		"requested_token_type": requestedTokenType,
+		"subject_token_type":   subjectTokenType,
+		"subject_token":        subjectToken,
+		"scope":                scope,
+	}
+	headerP := http.Header{
+		"Content-Type": ContentType,
+	}
+	paramsAuthentication := ClientAuthentication{
+		AuthStyle:    oauth2.AuthStyleInParams,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
+	paramsAuthentication.InjectAuthentication(valuesP, headerP)
+
+	if got, want := valuesP["audience"], audience; !reflect.DeepEqual(got, want) {
+		t.Errorf("audience = %q, want %q", got, want)
+	}
+	if got, want := valuesP["grant_type"], grantType; !reflect.DeepEqual(got, want) {
+		t.Errorf("grant_type = %q, want %q", got, want)
+	}
+	if got, want := valuesP["requested_token_type"], requestedTokenType; !reflect.DeepEqual(got, want) {
+		t.Errorf("requested_token_type = %q, want %q", got, want)
+	}
+	if got, want := valuesP["subject_token_type"], subjectTokenType; !reflect.DeepEqual(got, want) {
+		t.Errorf("subject_token_type = %q, want %q", got, want)
+	}
+	if got, want := valuesP["subject_token"], subjectToken; !reflect.DeepEqual(got, want) {
+		t.Errorf("subject_token = %q, want %q", got, want)
+	}
+	if got, want := valuesP["scope"], scope; !reflect.DeepEqual(got, want) {
+		t.Errorf("scope = %q, want %q", got, want)
+	}
+	if got, want := valuesP["client_id"], []string{clientID}; !reflect.DeepEqual(got, want) {
+		t.Errorf("client_id = %q, want %q", got, want)
+	}
+	if got, want := valuesP["client_secret"], []string{clientSecret}; !reflect.DeepEqual(got, want) {
+		t.Errorf("client_secret = %q, want %q", got, want)
+	}
+}

--- a/google/internal/externalaccount/err.go
+++ b/google/internal/externalaccount/err.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import "fmt"
+
+// Error for handling OAuth related error responses as stated in rfc6749#5.2.
+type Error struct {
+	Code        string
+	URI         string
+	Description string
+}
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("got error code %s from %s: %s", err.Code, err.URI, err.Description)
+}

--- a/google/internal/externalaccount/err_test.go
+++ b/google/internal/externalaccount/err_test.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import "testing"
+
+func TestError(t *testing.T) {
+	e := Error{
+		"42",
+		"http:thisIsAPlaceholder",
+		"The Answer!",
+	}
+	want := "got error code 42 from http:thisIsAPlaceholder: The Answer!"
+	if got := e.Error(); got != want {
+		t.Errorf("Got error message %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
These are used to support some extended utilities to help with STS requests.

Change-Id: Iafc145b06ca42374cfc2ac6572762a50bcf560f2
GitHub-Last-Rev: 3085fe570382318e6690304640751bf312e1a0b8
GitHub-Pull-Request: golang/oauth2#439
Reviewed-on: https://go-review.googlesource.com/c/oauth2/+/259777
Trust: Cody Oss <codyoss@google.com>
Run-TryBot: Cody Oss <codyoss@google.com>
TryBot-Result: Go Bot <gobot@golang.org>
Reviewed-by: Tyler Bui-Palsulich <tbp@google.com>